### PR TITLE
fix: ensure Buffer-type `data` is deserialised properly, fix signature result handling

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,6 +34,11 @@
     "lint": "tsdx lint src test",
     "prepare": "yarn lint && yarn build && yarn test"
   },
+  "dependencies": {
+    "@solana/web3.js": "^1.35.1",
+    "bs58": "^5.0.0",
+    "tweetnacl": "^1.0.3"
+  },
   "devDependencies": {
     "@types/jest": "^27.4.1",
     "@types/node": "13.7.0",
@@ -54,10 +59,5 @@
     "semi": true,
     "singleQuote": true,
     "trailingComma": "es5"
-  },
-  "dependencies": {
-    "@solana/web3.js": "^1.35.1",
-    "bs58": "^5.0.0",
-    "tweetnacl": "^1.0.3"
   }
 }

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "build:umd": "webpack",
     "build": "yarn clean && yarn build:cjs && yarn build:umd",
     "test": "tsdx test ./test",
+    "test:watch": "tsdx test --watch ./test",
     "lint": "tsdx lint src test",
     "prepare": "yarn lint && yarn build && yarn test"
   },

--- a/src/helpers/types.ts
+++ b/src/helpers/types.ts
@@ -14,7 +14,7 @@ export interface SolanaSignTransaction {
   feePayer: string;
   instructions: {
     programId: string;
-    data?: string;
+    data?: string | Buffer;
     keys: { isSigner: boolean; isWritable: boolean; pubkey: string }[];
   }[];
   recentBlockhash: string;

--- a/src/helpers/utils.ts
+++ b/src/helpers/utils.ts
@@ -6,6 +6,11 @@ import nacl from 'tweetnacl';
 export function deserialiseTransaction(
   seralised: SolanaSignTransaction
 ): Transaction {
+  const resolveInstructionData = (data?: string | Buffer) => {
+    if (!data) return Buffer.from([]);
+    return typeof data === 'string' ? Buffer.from(bs58.decode(data)) : data;
+  };
+
   const tx = new Transaction({
     recentBlockhash: seralised.recentBlockhash,
     feePayer: new PublicKey(bs58.decode(seralised.feePayer)),
@@ -14,7 +19,7 @@ export function deserialiseTransaction(
   tx.add(
     ...seralised.instructions.map(x => ({
       programId: new PublicKey(bs58.decode(x.programId)),
-      data: x.data ? Buffer.from(bs58.decode(x.data)) : Buffer.from([]),
+      data: resolveInstructionData(x.data),
       keys: x.keys.map(y => ({
         ...y,
         pubkey: new PublicKey(bs58.decode(y.pubkey)),

--- a/src/helpers/utils.ts
+++ b/src/helpers/utils.ts
@@ -8,7 +8,9 @@ export function deserialiseTransaction(
 ): Transaction {
   const resolveInstructionData = (data?: string | Buffer) => {
     if (!data) return Buffer.from([]);
-    return typeof data === 'string' ? Buffer.from(bs58.decode(data)) : data;
+    return typeof data === 'string'
+      ? Buffer.from(bs58.decode(data))
+      : Buffer.from(data);
   };
 
   const tx = new Transaction({

--- a/src/wallet.ts
+++ b/src/wallet.ts
@@ -30,16 +30,19 @@ export class SolanaWallet implements ISolanaWallet {
     }
 
     const transaction = deserialiseTransaction(serialisedTransaction);
-    await transaction.sign(this.keyPair);
 
-    const result = transaction.signatures[transaction.signatures.length - 1];
+    transaction.sign(this.keyPair);
 
-    if (!result?.signature) {
+    // From `Transaction.sign` documentation:
+    // The first signature is considered "primary" and is used identify and confirm transactions.
+    const primarySigPubkeyPair = transaction.signatures[0];
+
+    if (!primarySigPubkeyPair?.signature) {
       throw new Error('Missing signature');
     }
 
     return {
-      signature: bs58.encode(result.signature),
+      signature: bs58.encode(primarySigPubkeyPair.signature),
     };
   }
 

--- a/test/shared/values.ts
+++ b/test/shared/values.ts
@@ -19,16 +19,17 @@ export const TEST_TRANSACTION_SIGNATURE =
 export const TEST_RECENT_BLOCK_HASH =
   'F1bSUud8754dv3D4wB8LQb2m2snxiuPnLdNFCWfDPZDJ';
 
-export const TEST_TRANSACTION = new Transaction({
-  recentBlockhash: TEST_RECENT_BLOCK_HASH,
-  feePayer: new PublicKey(TEST_SOLANA_KEYPAIR_1.publicKey),
-}).add(
-  SystemProgram.transfer({
-    fromPubkey: new PublicKey(TEST_SOLANA_KEYPAIR_1.publicKey),
-    toPubkey: new PublicKey(TEST_SOLANA_KEYPAIR_2.publicKey),
-    lamports: 123,
-  })
-);
+export const createTestTransaction = () =>
+  new Transaction({
+    recentBlockhash: TEST_RECENT_BLOCK_HASH,
+    feePayer: new PublicKey(TEST_SOLANA_KEYPAIR_1.publicKey),
+  }).add(
+    SystemProgram.transfer({
+      fromPubkey: new PublicKey(TEST_SOLANA_KEYPAIR_1.publicKey),
+      toPubkey: new PublicKey(TEST_SOLANA_KEYPAIR_2.publicKey),
+      lamports: 123,
+    })
+  );
 
 export const TEST_MESSAGE = base58.encode(Buffer.from('hello world'));
 export const TEST_MESSAGE_SIGNATURE =

--- a/test/wallet.test.ts
+++ b/test/wallet.test.ts
@@ -75,7 +75,7 @@ describe('Wallet', () => {
 
       expect(result).toBeTruthy();
       expect(
-        await verifyTransactionSignature(
+        verifyTransactionSignature(
           account.pubkey,
           result.signature,
           TEST_TRANSACTION

--- a/test/wallet.test.ts
+++ b/test/wallet.test.ts
@@ -59,11 +59,10 @@ describe('Wallet', () => {
       const [account] = await wallet.getAccounts();
 
       const serialisedTx = serialiseTransaction(TEST_TRANSACTION);
-      // @ts-expect-error
       serialisedTx.instructions = serialisedTx.instructions.map(instr => {
         return {
           ...instr,
-          data: Buffer.from(base58.decode(instr.data!)),
+          data: Buffer.from(base58.decode(instr.data as string)),
         };
       });
 


### PR DESCRIPTION
### Description

* The `deserialiseTransaction` fn currently assumes that `instruction.data` is always a base58 string (which is only definitely true if the tx was originally serialised by `serialiseTransaction`).
* `@solana/web3.js` defines `data` as a `Buffer`: https://solana-labs.github.io/solana-web3.js/classes/TransactionInstruction.html#data
* This causes `deserialiseTransaction` to throw when it encounters a non base58 `data` value

### Changes

* Ensures that `deserialiseTransaction` accounts for `instruction.data` in the form of a `Buffer/UInt8Array`.
* Adds test for Buffer case.
* Ensures that `signTransaction` always returns the signature from the primary sigPubkeyPair.

### Validation

* Unit tests
* Tested locally with WalletConnect v2 example wallet and raydium.io